### PR TITLE
fix: Add version input into the Docker image tag list

### DIFF
--- a/.github/workflows/build-plugin-server-image-and-push.yml
+++ b/.github/workflows/build-plugin-server-image-and-push.yml
@@ -61,6 +61,7 @@ jobs:
             type=sha
             type=ref,event=tag
             type=semver,pattern={{version}}
+            type=raw,value=${{ inputs.version }},enable=${{ inputs.version != '' }}
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') || startsWith(github.ref, 'refs/tags/') }}
 
       - name: Login to Docker Registry


### PR DESCRIPTION
so when running the action via `workflow_dispatch`, the version input can work properly.