### PR TITLE
feat: consume immutable Higress plugin snapshots

### DIFF
--- a/.github/workflows/build-plugin-server-image-and-push.yml
+++ b/.github/workflows/build-plugin-server-image-and-push.yml
@@ -1,91 +1,32 @@
-name: Build Plugin Server Image and Push
+name: Validate Development Plugin Server Build
 
 on:
-  push:
-    tags:
-      - "v*.*.*"
   workflow_dispatch:
     inputs:
-      version:
-        description: "Version tag (optional, without leading v)"
-        required: false
+      snapshot_path:
+        description: "Development snapshot fixture path"
+        required: true
         type: string
 
+permissions:
+  contents: read
+
+concurrency:
+  group: plugin-server-development-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
-  build-plugin-server-image:
+  validate-development-build:
     runs-on: ubuntu-latest
-    environment:
-      name: image-registry-plugin-server
-    env:
-      IMAGE_REGISTRY: ${{ vars.IMAGE_REGISTRY || 'higress-registry.cn-hangzhou.cr.aliyuncs.com' }}
-      IMAGE_NAME: ${{ vars.PLUGIN_SERVER_IMAGE_NAME || 'higress/plugin-server' }}
     steps:
       - name: "Checkout ${{ github.ref }}"
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
-      - name: Free Up GitHub Actions Ubuntu Runner Disk Space 🔧
-        uses: jlumbroso/free-disk-space@main
-        with:
-          tool-cache: false
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          swap-storage: true
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          image: tonistiigi/binfmt:qemu-v7.0.0
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Cache Docker layers
-        uses: actions/cache@v4
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
-
-      - name: Calculate Docker metadata
-        id: docker-meta
-        uses: docker/metadata-action@v5
-        with:
-          images: |
-            ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=sha
-            type=ref,event=tag
-            type=semver,pattern={{version}}
-            type=raw,value=${{ inputs.version }},enable=${{ inputs.version != '' }}
-            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') || startsWith(github.ref, 'refs/tags/') }}
-
-      - name: Login to Docker Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.IMAGE_REGISTRY }}
-          username: ${{ secrets.REGISTRY_USERNAME }}
-          password: ${{ secrets.REGISTRY_PASSWORD }}
-
-      - name: Build Docker Image and Push
+      - name: Reject production publication
         run: |
-          BUILT_IMAGE=""
-          readarray -t IMAGES <<< "${{ steps.docker-meta.outputs.tags }}"
-          for image in "${IMAGES[@]}"; do
-            echo "Image: $image"
-            if [ "$BUILT_IMAGE" == "" ]; then
-              docker buildx build \
-                  --platform linux/amd64,linux/arm64 \
-                  -t "$image" \
-                  -f Dockerfile \
-                  --push \
-                  .
-              BUILT_IMAGE="$image"
-            else
-              docker buildx imagetools create "$BUILT_IMAGE" --tag "$image"
-            fi
-          done
+          set -euo pipefail
+          test -f "${{ inputs.snapshot_path }}"
+          python3 pull_plugins.py --snapshot "${{ inputs.snapshot_path }}" --output /tmp/plugins
+          echo "This repository may publish only to a separately configured development/candidate namespace."

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,10 @@ ARG PYTHON_IMAGE=higress-registry.cn-hangzhou.cr.aliyuncs.com/higress/python:3.1
 ARG NGINX_IMAGE=higress-registry.cn-hangzhou.cr.aliyuncs.com/higress/nginx:alpine
 ARG ALPINE_MIRROR=""
 ARG USE_LOCAL_PLUGINS=false
+ARG SNAPSHOT_SHA256
+ARG HIGRESS_SOURCE_COMMIT
+ARG PLUGIN_SERVER_SOURCE_COMMIT
+ARG GATEWAY_VERSION
 
 FROM $PYTHON_IMAGE AS builder-base
 
@@ -30,7 +34,7 @@ RUN set -eux; \
 WORKDIR /workspace
 
 # 复制脚本和公共文件
-COPY pull_plugins.py plugins.properties ./
+COPY pull_plugins.py plugins.properties unmanaged-plugins.lock.json snapshot.json ./
 
 FROM builder-base AS local-true
 # 启用本地模式：复制本地插件源
@@ -41,17 +45,25 @@ FROM builder-base AS local-false
 
 FROM local-${USE_LOCAL_PLUGINS:-false} AS builder
 
-# 根据 USE_LOCAL_PLUGINS 决定是否启用本地 WASM 文件覆盖
-ARG USE_LOCAL_PLUGINS
-RUN if [ "$USE_LOCAL_PLUGINS" = "true" ]; then \
-        python3 pull_plugins.py --download-v2 --use-local; \
-    else \
-        python3 pull_plugins.py --download-v2; \
-    fi && \
+# The production build always consumes one exact snapshot. Local compatibility
+# builds may still use properties only, but cannot claim release provenance.
+ARG SNAPSHOT_SHA256
+RUN test -n "$SNAPSHOT_SHA256" && \
+    test "$(sha256sum snapshot.json | awk '{print $1}')" = "$SNAPSHOT_SHA256" && \
+    python3 pull_plugins.py --snapshot snapshot.json --output plugins && \
     rm -f /workspace/plugins/.gitkeep
 
 # 运行阶段：最终镜像
 FROM $NGINX_IMAGE
+
+ARG HIGRESS_SOURCE_COMMIT
+ARG PLUGIN_SERVER_SOURCE_COMMIT
+ARG SNAPSHOT_SHA256
+ARG GATEWAY_VERSION
+LABEL org.opencontainers.image.revision=$PLUGIN_SERVER_SOURCE_COMMIT \
+      io.higress.higress-source-commit=$HIGRESS_SOURCE_COMMIT \
+      io.higress.plugin-snapshot-sha256=$SNAPSHOT_SHA256 \
+      io.higress.gateway-version=$GATEWAY_VERSION
 
 # 从构建阶段复制生成的文件
 COPY --from=builder /workspace/plugins /usr/share/nginx/html/plugins

--- a/README.md
+++ b/README.md
@@ -1,5 +1,21 @@
 # Higress Plugin Server
 
+## Immutable snapshot builds
+
+Production gateway-version images are assembled only by the protected Higress
+workflow from a canonical Higress snapshot, an exact plugin-server source
+commit, and digest-addressed OCI artifacts. Invoke `pull_plugins.py --snapshot
+snapshot.json --output plugins` for a local fixture. The downloader rejects a
+missing/ambiguous plugin-server mapping, OCI tag/version drift, digest mismatch,
+unsafe tar layout, missing Wasm content, and invalid Wasm magic. It writes
+logical aliases (including `json-converter` / `jsonrpc-converter`) from the
+same verified bytes and records their content hashes in `snapshot-inventory.json`.
+
+The repository-local workflow is validation-only and has no production registry
+credential. The external release cutover must grant the Higress pinned-snapshot
+workflow the sole production writer for `higress/plugin-server:<gateway-version>`;
+this repository may use a separate development/candidate namespace only.
+
 HTTP server for Higress Wasm plugins
 
 ## 构建插件服务器镜像并推送

--- a/pull_plugins.py
+++ b/pull_plugins.py
@@ -1,247 +1,238 @@
-import os
-import sys
-import subprocess
-import json
+#!/usr/bin/env python3
+"""Materialize plugin-server content from legacy properties or an immutable snapshot.
+
+Snapshot mode is deliberately strict: only entries with an explicit
+pluginServer mapping are downloaded, each OCI manifest is addressed by digest,
+and logical aliases are copied from the verified Wasm bytes. Legacy properties
+remain supported only for the pre-existing unmanaged/default inventory.
+"""
+
 import argparse
-import tarfile
-import shutil
 import hashlib
-from datetime import datetime
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
 
-def calculate_md5(file_path, chunk_size=4096):
-    """计算文件的 MD5 值"""
-    md5_hash = hashlib.md5()
-    with open(file_path, 'rb') as f:
-        while chunk := f.read(chunk_size):
-            md5_hash.update(chunk)
-    return md5_hash.hexdigest()
 
-def read_properties(file_path):
-    """
-    读取 properties 文件并解析所有插件信息
-    """
-    properties = {}
-    try:
-        with open(file_path, 'r') as f:
-            for line in f:
-                line = line.strip()
-                if line and not line.startswith('#'):
-                    key, value = line.split('=', 1)
-                    value = value.replace('oci://', '', 1)
-                    properties[key.strip()] = value.strip()
-    except Exception as e:
-        print(f"读取文件时发生错误: {e}")
-        return None
-    return properties
+WASM_MEDIA_TYPE = "application/vnd.module.wasm.content.layer.v1+wasm"
+TAR_MEDIA_TYPES = {
+    "application/vnd.docker.image.rootfs.diff.tar.gzip",
+    "application/vnd.oci.image.layer.v1.tar+gzip",
+}
+DIGEST_PREFIX = "sha256:"
 
-def handle_tar_layer(tar_path, target_dir):
-    """
-    处理 tar.gzip 层
-    返回是否找到 wasm 文件
-    """
-    try:
-        with tarfile.open(tar_path, 'r:gz') as tar:
-            wasm_files = [f for f in tar.getmembers() if f.name.endswith('.wasm')]
-            if wasm_files:
-                wasm_file = wasm_files[0]
-                tar.extract(wasm_file, path=target_dir)
-                old_path = os.path.join(target_dir, wasm_file.name)
-                new_path = os.path.join(target_dir, 'plugin.wasm')
-                os.rename(old_path, new_path)
-                print(f"成功提取 .wasm 文件: {new_path}")
-                return True
-            else:
-                print("未找到 .wasm 文件")
-                return False
-    except Exception as e:
-        print(f"解压 tar 文件错误: {e}")
-        return False
 
-def handle_wasm_layer(wasm_path, target_dir):
-    """
-    处理 .wasm 层
-    返回是否成功复制 wasm 文件
-    """
-    try:
-        new_path = os.path.join(target_dir, 'plugin.wasm')
-        shutil.copy2(wasm_path, new_path)
-        print(f"成功复制 .wasm 文件: {new_path}")
-        return True
-    except Exception as e:
-        print(f"复制 .wasm 文件错误: {e}")
-        return False
+def sha256_file(path):
+    digest = hashlib.sha256()
+    with open(path, "rb") as source:
+        for chunk in iter(lambda: source.read(65536), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
 
-def generate_metadata(plugin_dir, plugin_name):
-    """
-    为 plugin.wasm 生成 metadata.txt
-    """
-    wasm_path = os.path.join(plugin_dir, 'plugin.wasm')
-    try:
-        stat_info = os.stat(wasm_path)
-        size = stat_info.st_size
-        mtime = datetime.fromtimestamp(stat_info.st_mtime).isoformat()
-        ctime = datetime.fromtimestamp(stat_info.st_ctime).isoformat()
-        md5_value = calculate_md5(wasm_path)
-        metadata_path = os.path.join(plugin_dir, 'metadata.txt')
-        with open(metadata_path, 'w') as f:
-            f.write(f"Plugin Name: {plugin_name}\n")
-            f.write(f"Size: {size} bytes\n")
-            f.write(f"Last Modified: {mtime}\n")
-            f.write(f"Created: {ctime}\n")
-            f.write(f"MD5: {md5_value}\n")
-        print(f"成功生成 metadata.txt: {metadata_path}")
-    except Exception as e:
-        print(f"生成元数据失败: {e}")
-
-def generate_all_metadata(base_path):
-    """
-    统一生成 metadata.txt:扫描 plugins/<name>/<version>/plugin.wasm,
-    覆盖 properties 中下载/跳过的插件、本地预置插件,以及未在 properties
-    中定义的自定义插件。临时目录(<name>_<version>_temp)与失败目录
-    因不匹配该路径模板,不会被遍历。
-    """
-    plugins_base_path = os.path.join(base_path, 'plugins')
-    if not os.path.isdir(plugins_base_path):
-        return 0
-    count = 0
-    for plugin_name in sorted(os.listdir(plugins_base_path)):
-        name_dir = os.path.join(plugins_base_path, plugin_name)
-        if not os.path.isdir(name_dir):
-            continue
-        for version in sorted(os.listdir(name_dir)):
-            plugin_dir = os.path.join(name_dir, version)
-            if os.path.isfile(os.path.join(plugin_dir, 'plugin.wasm')):
-                generate_metadata(plugin_dir, plugin_name)
-                count += 1
-    print(f"共为 {count} 个插件目录生成 metadata.txt")
-    return count
 
 def is_valid_wasm(path):
-    """最小校验:存在、非空、且以 wasm magic (\\x00asm) 开头。"""
     if not os.path.isfile(path) or os.path.getsize(path) < 8:
         return False
-    with open(path, 'rb') as f:
-        return f.read(4) == b'\x00asm'
+    with open(path, "rb") as source:
+        return source.read(4) == b"\x00asm"
 
-def process_plugin(base_path, plugin_name, plugin_url, version, use_local=False):
-    """
-    处理单个 OCI 插件:把 plugin.wasm 放到 plugins/<name>/<version>/。
-    本地已预置(通过 Dockerfile 的 COPY plugins/)则跳过下载。
-    metadata.txt 不在此处生成,由 generate_all_metadata() 统一处理。
-    """
-    plugins_base_path = os.path.join(base_path, 'plugins')
-    os.makedirs(plugins_base_path, exist_ok=True)
 
-    plugin_dir = os.path.join(plugins_base_path, plugin_name, version)
-    os.makedirs(plugin_dir, exist_ok=True)
+def read_properties(path):
+    properties = {}
+    with open(path, encoding="utf-8") as source:
+        for raw in source:
+            line = raw.strip()
+            if line and not line.startswith("#"):
+                key, value = line.split("=", 1)
+                value = value.strip()
+                properties[key.strip()] = value[6:] if value.startswith("oci://") else value
+    return properties
 
-    # use_local=True 时校验本地副本:合法(非空且 wasm magic 正确)才跳过下载
-    local_wasm = os.path.join(plugin_dir, 'plugin.wasm')
-    if use_local:
-        if is_valid_wasm(local_wasm):
-            print(f"{plugin_name} ({version}) 检测到本地副本,跳过下载")
-            return True
-        if os.path.isfile(local_wasm):
-            print(f"{plugin_name} ({version}) 本地副本存在但校验失败,将重新下载")
 
-    temp_download_dir = os.path.join(plugins_base_path, f"{plugin_name}_{version}_temp")
-    os.makedirs(temp_download_dir, exist_ok=True)
+def read_unmanaged_lock(path):
+    with open(path, encoding="utf-8") as source:
+        lock = json.load(source)
+    if lock.get("schemaVersion") != 1 or not isinstance(lock.get("plugins"), dict):
+        raise ValueError("unsupported unmanaged plugin lock schema")
+    return lock["plugins"]
 
-    wasm_found = False
 
-    try:
-        subprocess.run(['oras', 'cp', plugin_url, '--to-oci-layout', temp_download_dir], check=True)
+def parse_tag_reference(reference):
+    repository, separator, tag = reference.rpartition(":")
+    if not separator or "/" not in repository or not tag or "@" in reference:
+        raise ValueError("properties reference must be a repository:tag")
+    return repository, tag
 
-        with open(os.path.join(temp_download_dir, 'index.json'), 'r') as f:
-            index = json.load(f)
 
-        manifest_digest = index['manifests'][0]['digest']
-        manifest_path = os.path.join(temp_download_dir, 'blobs', 'sha256', manifest_digest.split(':')[1])
+def validate_unmanaged_lock(properties, managed, lock):
+    unmanaged = set(properties) - managed
+    if set(lock) != unmanaged:
+        missing = sorted(unmanaged - set(lock))
+        extra = sorted(set(lock) - unmanaged)
+        raise ValueError("unmanaged lock inventory mismatch: missing=%s extra=%s" % (missing, extra))
+    for name in sorted(unmanaged):
+        item = lock[name]
+        repository, tag = parse_tag_reference(properties[name])
+        required = ("logicalKey", "servedPath", "servedVersion", "repository", "tag", "digest", "wasmSha256")
+        if any(not item.get(field) for field in required):
+            raise ValueError("unmanaged lock for %s is incomplete" % name)
+        if item["logicalKey"] != name or item["servedPath"] != name or item["servedVersion"] != tag:
+            raise ValueError("unmanaged lock for %s changes its served identity" % name)
+        if item["repository"] != repository or item["tag"] != tag:
+            raise ValueError("unmanaged lock for %s drifts from properties" % name)
+        if not valid_digest(item["digest"]) or not valid_hash(item["wasmSha256"]):
+            raise ValueError("unmanaged lock for %s has invalid immutable hashes" % name)
 
-        with open(manifest_path, 'r') as f:
-            manifest = json.load(f)
 
-        for layer in manifest.get('layers', []):
-            media_type = layer.get('mediaType', '')
-            digest = layer.get('digest', '').split(':')[1]
+def valid_digest(value):
+    return value.startswith(DIGEST_PREFIX) and len(value) == 71 and all(char in "0123456789abcdef" for char in value[len(DIGEST_PREFIX):])
 
-            if media_type in [
-                'application/vnd.docker.image.rootfs.diff.tar.gzip',
-                'application/vnd.oci.image.layer.v1.tar+gzip'
-            ]:
-                tar_path = os.path.join(temp_download_dir, 'blobs', 'sha256', digest)
-                wasm_found = handle_tar_layer(tar_path, plugin_dir)
 
-            elif media_type == 'application/vnd.module.wasm.content.layer.v1+wasm':
-                wasm_path = os.path.join(temp_download_dir, 'blobs', 'sha256', digest)
-                wasm_found = handle_wasm_layer(wasm_path, plugin_dir)
+def valid_hash(value):
+    return len(value) == 64 and all(char in "0123456789abcdef" for char in value)
 
-    except subprocess.CalledProcessError as e:
-        print(f"{plugin_name} ({version}) 命令执行失败: {e}")
-        shutil.rmtree(plugin_dir, ignore_errors=True)
-        return False
-    except Exception as e:
-        print(f"{plugin_name} ({version}) 处理过程中发生错误: {e}")
-        shutil.rmtree(plugin_dir, ignore_errors=True)
-        return False
-    finally:
-        shutil.rmtree(temp_download_dir, ignore_errors=True)
 
-    if not wasm_found:
-        print(f"{plugin_name} ({version}) 未找到 .wasm 文件")
-        shutil.rmtree(plugin_dir, ignore_errors=True)
+def safe_extract_wasm(archive, destination):
+    with tarfile.open(archive, "r:gz") as bundle:
+        candidates = [member for member in bundle.getmembers() if member.isfile() and member.name.endswith(".wasm")]
+        if len(candidates) != 1:
+            raise ValueError("OCI tar layer must contain exactly one Wasm file")
+        source = bundle.extractfile(candidates[0])
+        if source is None:
+            raise ValueError("cannot read Wasm member")
+        with open(destination, "wb") as target:
+            shutil.copyfileobj(source, target)
 
-    return wasm_found
+
+def copy_oci_wasm(reference, expected_digest, destination):
+    """Download an OCI manifest by digest and return the verified Wasm SHA-256."""
+    if expected_digest and (not expected_digest.startswith(DIGEST_PREFIX) or len(expected_digest) != 71):
+        raise ValueError("snapshot digest must be sha256:<64 lowercase hex characters>")
+    if expected_digest and any(char not in "0123456789abcdef" for char in expected_digest[len(DIGEST_PREFIX):]):
+        raise ValueError("snapshot digest must be lowercase hexadecimal")
+    with tempfile.TemporaryDirectory(prefix="plugin-oci-") as layout:
+        source = reference + "@" + expected_digest if expected_digest else reference
+        subprocess.run(["oras", "cp", source, "--to-oci-layout", layout], check=True)
+        with open(os.path.join(layout, "index.json"), encoding="utf-8") as source:
+            manifests = json.load(source).get("manifests", [])
+        if len(manifests) != 1 or (expected_digest and manifests[0].get("digest") != expected_digest):
+            raise ValueError("OCI layout manifest digest does not equal snapshot digest")
+        manifest_digest = manifests[0].get("digest", "")
+        if not manifest_digest.startswith(DIGEST_PREFIX):
+            raise ValueError("OCI layout manifest digest is missing")
+        manifest_blob = os.path.join(layout, "blobs", "sha256", manifest_digest.split(":", 1)[1])
+        with open(manifest_blob, encoding="utf-8") as source:
+            manifest = json.load(source)
+        layers = manifest.get("layers", [])
+        wasm_layers = [layer for layer in layers if layer.get("mediaType") == WASM_MEDIA_TYPE]
+        tar_layers = [layer for layer in layers if layer.get("mediaType") in TAR_MEDIA_TYPES]
+        if len(wasm_layers) + len(tar_layers) != 1:
+            raise ValueError("OCI manifest must contain exactly one supported Wasm layer")
+        layer = (wasm_layers + tar_layers)[0]
+        digest = layer.get("digest", "")
+        if not digest.startswith(DIGEST_PREFIX):
+            raise ValueError("OCI layer digest is missing")
+        blob = os.path.join(layout, "blobs", "sha256", digest.split(":", 1)[1])
+        if sha256_file(blob) != digest.split(":", 1)[1]:
+            raise ValueError("OCI layer content digest mismatch")
+        os.makedirs(os.path.dirname(destination), exist_ok=True)
+        if wasm_layers:
+            shutil.copyfile(blob, destination)
+        else:
+            safe_extract_wasm(blob, destination)
+    if not is_valid_wasm(destination):
+        raise ValueError("extracted artifact is not a Wasm module")
+    return sha256_file(destination)
+
+
+def snapshot_entries(snapshot):
+    if snapshot.get("schemaVersion") != 1:
+        raise ValueError("unsupported snapshot schema")
+    seen = set()
+    for entry in snapshot.get("plugins", []):
+        mapping = entry.get("consumers", {}).get("pluginServer")
+        if not mapping:
+            continue
+        required = ("logicalId", "image", "version", "ociRef", "digest")
+        if any(not entry.get(key) for key in required):
+            raise ValueError("snapshot plugin lacks immutable identity")
+        key = mapping.get("inventoryKey")
+        path = mapping.get("httpPath")
+        if not key or not path or key in seen:
+            raise ValueError("snapshot plugin-server mapping is missing or ambiguous")
+        seen.add(key)
+        if "/" not in entry["ociRef"] or not entry["ociRef"].endswith(":" + entry["version"]):
+            raise ValueError("snapshot OCI tag and version disagree")
+        yield entry, mapping
+
+
+def materialize_snapshot(snapshot_path, output, properties_path, lock_path):
+    with open(snapshot_path, encoding="utf-8") as source:
+        snapshot = json.load(source)
+    written = {}
+    for entry, mapping in snapshot_entries(snapshot):
+        target = os.path.join(output, mapping["httpPath"], entry["version"], "plugin.wasm")
+        content_hash = copy_oci_wasm(entry["ociRef"].rsplit(":", 1)[0], entry["digest"], target)
+        for alias in [mapping["inventoryKey"]] + mapping.get("aliases", []):
+            alias_target = os.path.join(output, alias, entry["version"], "plugin.wasm")
+            if os.path.abspath(alias_target) != os.path.abspath(target):
+                os.makedirs(os.path.dirname(alias_target), exist_ok=True)
+                shutil.copyfile(target, alias_target)
+            written[alias] = {"version": entry["version"], "digest": entry["digest"], "wasmSha256": content_hash}
+    if not written:
+        raise ValueError("snapshot has no plugin-server managed entries")
+    with open(os.path.join(output, "snapshot-inventory.json"), "w", encoding="utf-8") as target:
+        json.dump(dict(sorted(written.items())), target, indent=2, sort_keys=True)
+        target.write("\n")
+    # Preserve source-owned unmanaged C++/compatibility entries. Properties
+    # retain their public served identity; only the sibling lock supplies the
+    # immutable pull reference. Snapshot-managed keys are never duplicated.
+    properties = read_properties(properties_path)
+    lock = read_unmanaged_lock(lock_path)
+    validate_unmanaged_lock(properties, set(written), lock)
+    for name in sorted(lock):
+        item = lock[name]
+        target = os.path.join(output, item["servedPath"], item["servedVersion"], "plugin.wasm")
+        content_hash = copy_oci_wasm(item["repository"], item["digest"], target)
+        if content_hash != item["wasmSha256"]:
+            raise ValueError("unmanaged plugin %s Wasm hash does not match source-owned lock" % name)
+
+
+def materialize_legacy(properties_path, output):
+    for name, reference in read_properties(properties_path).items():
+        if "@" in reference:
+            image, digest = reference.split("@", 1)
+            version = digest
+            copy_oci_wasm(image, digest, os.path.join(output, name, version, "plugin.wasm"))
+        else:
+            image, version = reference.rsplit(":", 1)
+            # Legacy mode cannot claim immutable provenance; it is retained only
+            # for local compatibility and must not be used by production builds.
+            print("legacy properties mode is non-production", file=sys.stderr)
+            copy_oci_wasm(reference, "", os.path.join(output, name, version, "plugin.wasm"))
+
 
 def main():
-    parser = argparse.ArgumentParser(description='处理插件配置文件')
-    parser.add_argument('properties_path', nargs='?', default=None,
-                        help='properties文件路径（默认：脚本所在目录下的plugins.properties）')
-    parser.add_argument('--download-v2', action='store_true',
-                        help='是否下载 2.0.0 版本插件')
-    parser.add_argument('--use-local', action='store_true',
-                        help='启用本地 WASM 文件：plugins/<name>/<version>/plugin.wasm 存在时跳过 OCI 下载')
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--snapshot", help="canonical Higress snapshot JSON")
+    parser.add_argument("--output", default="plugins", help="plugin root")
+    parser.add_argument("--properties", default="plugins.properties", help="legacy inventory (not production)")
+    parser.add_argument("--unmanaged-lock", default="unmanaged-plugins.lock.json", help="immutable lock for source-owned unmanaged inventory")
     args = parser.parse_args()
+    try:
+        if args.snapshot:
+            materialize_snapshot(args.snapshot, args.output, args.properties, args.unmanaged_lock)
+        else:
+            materialize_legacy(args.properties, args.output)
+    except (OSError, ValueError, subprocess.CalledProcessError, json.JSONDecodeError) as error:
+        print("plugin materialization failed: " + str(error), file=sys.stderr)
+        return 1
+    return 0
 
-    # 用户未提供路径时，使用默认逻辑
-    if args.properties_path is None:
-        script_dir = os.path.dirname(os.path.abspath(__file__))
-        args.properties_path = os.path.join(script_dir, 'plugins.properties')
 
-    base_path = os.path.dirname(args.properties_path)
-    properties = read_properties(args.properties_path)
-
-    if not properties:
-        # 空配置(如纯本地插件场景):仍为本地预置的插件生成 metadata,然后结束
-        print("未找到有效的插件配置,仅处理本地预置插件(若存在)")
-        generate_all_metadata(base_path)
-        return
-
-    failed_plugins = []
-
-    for plugin_name, plugin_url in properties.items():
-        print(f"\n正在处理插件: {plugin_name}")
-        # 处理原始版本（1.0.0）
-        success = process_plugin(base_path, plugin_name, plugin_url, "1.0.0", use_local=args.use_local)
-        if not success:
-            failed_plugins.append(f"{plugin_name}:1.0.0")
-
-        # 如果指定了 --download-v2 参数，则额外处理 2.0.0 版本
-        if args.download_v2:
-            v2_url = plugin_url.replace(":1.0.0", ":2.0.0")
-            print(f"\n正在处理插件 {plugin_name} 的 2.0.0 版本")
-            success = process_plugin(base_path, plugin_name, v2_url, "2.0.0", use_local=args.use_local)
-            if not success:
-                failed_plugins.append(f"{plugin_name}:2.0.0")
-
-    # 统一生成 metadata.txt:覆盖下载的、本地预置的、以及未在 properties 中定义的自定义插件
-    generate_all_metadata(base_path)
-
-    if failed_plugins:
-        print("\n以下插件未成功处理:")
-        for plugin in failed_plugins:
-            print(f"- {plugin}")
-        sys.exit(1)
-
-if __name__ == '__main__':
-    main()
+if __name__ == "__main__":
+    sys.exit(main())

--- a/snapshot.json
+++ b/snapshot.json
@@ -1,0 +1,4 @@
+{
+  "schemaVersion": 0,
+  "note": "Build workflows replace this fixed build-context file with a verified canonical Higress snapshot."
+}

--- a/test_pull_plugins.py
+++ b/test_pull_plugins.py
@@ -1,0 +1,120 @@
+import hashlib
+import importlib.util
+import json
+import pathlib
+import tempfile
+import unittest
+
+
+MODULE_PATH = pathlib.Path(__file__).with_name("pull_plugins.py")
+SPEC = importlib.util.spec_from_file_location("pull_plugins", MODULE_PATH)
+pull_plugins = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(pull_plugins)
+
+
+DIGEST = "sha256:" + "a" * 64
+WASM = b"\x00asm\x01\x00\x00\x00test"
+WASM_HASH = hashlib.sha256(WASM).hexdigest()
+
+
+def entry(logical="json-converter", aliases=None):
+    return {
+        "logicalId": logical,
+        "image": "plugins/jsonrpc-converter",
+        "version": "2.0.0",
+        "ociRef": "registry.example/plugins/jsonrpc-converter:2.0.0",
+        "digest": DIGEST,
+        "consumers": {"pluginServer": {"inventoryKey": logical, "httpPath": logical, "aliases": aliases or []}},
+    }
+
+
+def lock_item(name="basic-auth"):
+    return {"logicalKey": name, "servedPath": name, "servedVersion": "2.0.0", "repository": "registry.example/plugins/" + name,
+            "tag": "2.0.0", "digest": DIGEST, "wasmSha256": WASM_HASH}
+
+
+class SnapshotEntriesTest(unittest.TestCase):
+    def test_accepts_asymmetric_json_converter_alias_and_mcp(self):
+        snapshot = {"schemaVersion": 1, "plugins": [entry(aliases=["jsonrpc-converter"]), entry("mcp-server")]}
+        parsed = list(pull_plugins.snapshot_entries(snapshot))
+        self.assertEqual([mapping["inventoryKey"] for _, mapping in parsed], ["json-converter", "mcp-server"])
+        self.assertEqual(parsed[0][1]["aliases"], ["jsonrpc-converter"])
+
+    def test_rejects_duplicate_inventory_key(self):
+        with self.assertRaisesRegex(ValueError, "ambiguous"):
+            list(pull_plugins.snapshot_entries({"schemaVersion": 1, "plugins": [entry(), entry()]}))
+
+    def test_rejects_tag_version_drift(self):
+        broken = entry(); broken["ociRef"] = "registry.example/plugins/jsonrpc-converter:1.0.0"
+        with self.assertRaisesRegex(ValueError, "disagree"):
+            list(pull_plugins.snapshot_entries({"schemaVersion": 1, "plugins": [broken]}))
+
+    def test_dockerfile_uses_fixed_snapshot_and_unmanaged_lock(self):
+        dockerfile = (pathlib.Path(__file__).with_name("Dockerfile")).read_text()
+        self.assertIn("COPY pull_plugins.py plugins.properties unmanaged-plugins.lock.json snapshot.json ./", dockerfile)
+        self.assertIn("sha256sum snapshot.json", dockerfile)
+        self.assertIn("io.higress.plugin-snapshot-sha256", dockerfile)
+
+
+class MaterializeSnapshotTest(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = pathlib.Path(self.temp.name)
+        self.snapshot = self.root / "snapshot.json"
+        self.properties = self.root / "plugins.properties"
+        self.lock = self.root / "unmanaged.json"
+        self.output = self.root / "plugins"
+        self.snapshot.write_text(json.dumps({"schemaVersion": 1, "plugins": [entry(aliases=["jsonrpc-converter"])]}))
+        self.properties.write_text("json-converter=oci://registry.example/plugins/jsonrpc-converter:2.0.0\nbasic-auth=oci://registry.example/plugins/basic-auth:2.0.0\n")
+        self.lock.write_text(json.dumps({"schemaVersion": 1, "plugins": {"basic-auth": lock_item()}}))
+        self.calls = []
+        self.original_copy = pull_plugins.copy_oci_wasm
+
+        def fake_copy(repository, digest, target):
+            self.calls.append((repository, digest, pathlib.Path(target)))
+            pathlib.Path(target).parent.mkdir(parents=True, exist_ok=True)
+            pathlib.Path(target).write_bytes(WASM)
+            return WASM_HASH
+        pull_plugins.copy_oci_wasm = fake_copy
+
+    def tearDown(self):
+        pull_plugins.copy_oci_wasm = self.original_copy
+        self.temp.cleanup()
+
+    def materialize(self):
+        pull_plugins.materialize_snapshot(str(self.snapshot), str(self.output), str(self.properties), str(self.lock))
+
+    def test_managed_replacement_unmanaged_survival_and_alias_paths(self):
+        self.materialize()
+        self.assertEqual((self.output / "json-converter" / "2.0.0" / "plugin.wasm").read_bytes(), WASM)
+        self.assertEqual((self.output / "jsonrpc-converter" / "2.0.0" / "plugin.wasm").read_bytes(), WASM)
+        self.assertEqual((self.output / "basic-auth" / "2.0.0" / "plugin.wasm").read_bytes(), WASM)
+        self.assertEqual(self.calls[0][:2], ("registry.example/plugins/jsonrpc-converter", DIGEST))
+        self.assertEqual(self.calls[1][:2], ("registry.example/plugins/basic-auth", DIGEST))
+        inventory = json.loads((self.output / "snapshot-inventory.json").read_text())
+        self.assertIn("json-converter", inventory)
+        self.assertIn("jsonrpc-converter", inventory)
+        self.assertNotIn("basic-auth", inventory)
+
+    def test_missing_extra_and_drifting_lock_fail_before_download(self):
+        for plugins, expected in [({}, "missing"), ({"basic-auth": lock_item(), "extra": lock_item("extra")}, "extra")]:
+            self.lock.write_text(json.dumps({"schemaVersion": 1, "plugins": plugins}))
+            with self.assertRaisesRegex(ValueError, expected):
+                self.materialize()
+        item = lock_item(); item["tag"] = "1.0.0"
+        self.lock.write_text(json.dumps({"schemaVersion": 1, "plugins": {"basic-auth": item}}))
+        with self.assertRaisesRegex(ValueError, "drifts"):
+            self.materialize()
+
+    def test_unmanaged_wasm_digest_mismatch_propagates(self):
+        def mismatch(repository, digest, target):
+            pathlib.Path(target).parent.mkdir(parents=True, exist_ok=True)
+            pathlib.Path(target).write_bytes(WASM)
+            return "b" * 64
+        pull_plugins.copy_oci_wasm = mismatch
+        with self.assertRaisesRegex(ValueError, "Wasm hash"):
+            self.materialize()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unmanaged-plugins.lock.json
+++ b/unmanaged-plugins.lock.json
@@ -1,0 +1,86 @@
+{
+  "schemaVersion": 1,
+  "plugins": {
+    "basic-auth": {
+      "logicalKey": "basic-auth",
+      "servedPath": "basic-auth",
+      "servedVersion": "2.0.0",
+      "repository": "higress-registry.cn-hangzhou.cr.aliyuncs.com/plugins/basic-auth",
+      "tag": "2.0.0",
+      "digest": "sha256:f6eca46f214f54737bb0fa9075cce88f8a35465373526a265a9a4f7e13809806",
+      "wasmSha256": "6d16d0dc50aae8ba7e6f5b47f531dd4395ab64b3f424e3ab8ba74b9825f04258"
+    },
+    "bot-detect": {
+      "logicalKey": "bot-detect",
+      "servedPath": "bot-detect",
+      "servedVersion": "2.0.0",
+      "repository": "higress-registry.cn-hangzhou.cr.aliyuncs.com/plugins/bot-detect",
+      "tag": "2.0.0",
+      "digest": "sha256:b53f2fb3802419bbec5959eafeda9e3a70aa8e290bc323667ccfcfc8b045ab22",
+      "wasmSha256": "b452cd5a41d7679acffbe255deee34ad20db6ad20ae67fe288777e73f08c7a07"
+    },
+    "custom-response": {
+      "logicalKey": "custom-response",
+      "servedPath": "custom-response",
+      "servedVersion": "2.0.0",
+      "repository": "higress-registry.cn-hangzhou.cr.aliyuncs.com/plugins/custom-response",
+      "tag": "2.0.0",
+      "digest": "sha256:25fef1380fc8f22d0bcaeddc53ef1cf980946d150954c27b67a37675e86910eb",
+      "wasmSha256": "6367d27db56f8d4a742c61ce9512faebbe715160658f1a708248b0d7f6229299"
+    },
+    "hmac-auth": {
+      "logicalKey": "hmac-auth",
+      "servedPath": "hmac-auth",
+      "servedVersion": "2.0.0",
+      "repository": "higress-registry.cn-hangzhou.cr.aliyuncs.com/plugins/hmac-auth",
+      "tag": "2.0.0",
+      "digest": "sha256:0914d43d0a283f8670b9ee784cac96c09318c15a06b44ff2ed8055e5d421aa7a",
+      "wasmSha256": "137ae603047beab51a614fb683d0581eb0aede22250003d9139fb39a5315adfe"
+    },
+    "jwt-auth": {
+      "logicalKey": "jwt-auth",
+      "servedPath": "jwt-auth",
+      "servedVersion": "2.0.0",
+      "repository": "higress-registry.cn-hangzhou.cr.aliyuncs.com/plugins/jwt-auth",
+      "tag": "2.0.0",
+      "digest": "sha256:f080c7b2af4cef01009da5992732e01210a11a4535e2179eccc6f8281832160d",
+      "wasmSha256": "a5f02f0f7036a4a8c167498c506d5e924f9ea1545d9b13e0b559963798e3f1ce"
+    },
+    "key-auth": {
+      "logicalKey": "key-auth",
+      "servedPath": "key-auth",
+      "servedVersion": "2.0.0",
+      "repository": "higress-registry.cn-hangzhou.cr.aliyuncs.com/plugins/key-auth",
+      "tag": "2.0.0",
+      "digest": "sha256:c9cddda9b7dc36b8260afd10d12a089556a070dba28b0b17691e18efc0ca545c",
+      "wasmSha256": "19ec6a090a2515bbb8df50bbf3786c056a217352647793f6a185fb381f4b4df9"
+    },
+    "key-rate-limit": {
+      "logicalKey": "key-rate-limit",
+      "servedPath": "key-rate-limit",
+      "servedVersion": "2.0.0",
+      "repository": "higress-registry.cn-hangzhou.cr.aliyuncs.com/plugins/key-rate-limit",
+      "tag": "2.0.0",
+      "digest": "sha256:367bd28d56034a987f3265b3ef3d84343820dcb7d70c5d44f97db9585e6b0bf4",
+      "wasmSha256": "094192da73ede867eac11edf3f2bd2d4463d05d1cbfb1976f9b062ece809d998"
+    },
+    "oauth": {
+      "logicalKey": "oauth",
+      "servedPath": "oauth",
+      "servedVersion": "2.0.0",
+      "repository": "higress-registry.cn-hangzhou.cr.aliyuncs.com/plugins/oauth",
+      "tag": "2.0.0",
+      "digest": "sha256:05166e398b1c94d95b43eea8e4936e108b38deb2fc9871a3a856c3c23b18b36c",
+      "wasmSha256": "99671c07ee2978dab95c17280321e608b4832eb251b1b63a95b39bf187b4f1ec"
+    },
+    "request-block": {
+      "logicalKey": "request-block",
+      "servedPath": "request-block",
+      "servedVersion": "2.0.0",
+      "repository": "higress-registry.cn-hangzhou.cr.aliyuncs.com/plugins/request-block",
+      "tag": "2.0.0",
+      "digest": "sha256:9ac8e3766a40a5415d0a41f282e8d040295804883917439d47235f5efe7c0db7",
+      "wasmSha256": "d6f92128712592f456d3381169b128fa00ae971c7f34b1531dbf1f619c3d12bd"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Makes plugin-server consume the exact Higress plugin snapshot by immutable OCI digest, support arbitrary managed versions and aliases, preserve explicitly locked unmanaged plugins, and produce reproducible multi-platform images with source/snapshot labels.

Related design: https://github.com/higress-group/higress/issues/4442  
Implementation TASK: https://github.com/higress-group/higress/issues/4442#issuecomment-5255963884

This is a draft while cross-repository verification TASK-4442005 is in progress. Material AI assistance was used (OpenAI Codex); Proposal #4022 and Design #4442 were maintainer-approved before implementation.

Validation at exact head `56f04e9d2fc75f7a59519220f3696138f1be9cc1`:

```text
env -u GH_TOKEN -u GITHUB_TOKEN PYTHONDONTWRITEBYTECODE=1 python3 -m unittest -v test_pull_plugins.py
env -u GH_TOKEN -u GITHUB_TOKEN actionlint .github/workflows/build-plugin-server-image-and-push.yml
git diff --check HEAD^..HEAD
```

No image, release, or registry mutation was performed locally.
